### PR TITLE
Unofficial Build OTA Update

### DIFF
--- a/builds/avicii.json
+++ b/builds/avicii.json
@@ -1,16 +1,16 @@
 {
         "response": [
                 {
-                        "maintainer": "Snippetguy",
+                        "maintainer": "PSavarMattas",
                         "oem": "Oneplus",
                         "device": "Oneplus Nord",
-                        "filename": "Cherish-OS-v4.7.5-20230429-0826-avicii-OFFICIAL-GApps.zip",
-                        "download": "https://sourceforge.net/projects/cherish-os/files/device/avicii/Cherish-OS-v4.7.5-20230429-0826-avicii-OFFICIAL-GApps.zip/download",
+                        "filename": "Cherish-OS-v4.8-20230608-0903-avicii-UNOFFICIAL-GApps.zip",
+                        "download": "https://sourceforge.net/projects/cherishos-avicii/files/Cherish-OS-v4.8-20230608-0903-avicii-UNOFFICIAL-GApps.zip/download",
                         "timestamp": 1682756779,
                         "md5": "f185bf66277a6891fe01efdd173945ec",
                         "sha256": "b1e753281204f7a4ed50a8a7b5a0ced08feec4cabc115e71a30591245ee2ceca",
                         "size": 1897795540,
-                        "version": 4.7.5,
+                        "version": 4.8,
                         "buildtype": "Active Development Releases",
                         "forum": "https://t.me/cherishOS",
                         "gapps": "",
@@ -19,10 +19,10 @@
                         "bootloader": "",
                         "recovery": "",
                         "paypal": "https://www.paypal.me/hungphan2001",
-                        "telegram": "https://t.me/snippetroms",
-                        "dt": "https://github.com/Sandeep-FED/android_device_oneplus_avicii",
+                        "telegram": "https://t.me/psmbuilds",
+                        "dt": "https://github.com/psavarmattas/device_oneplus_avicii.git",
                         "common-dt": "",
-                        "kernel": "https://github.com/Sandeep-FED/android_kernel_oneplus_sm7250"
+                        "kernel": "https://github.com/psavarmattas/kernel_oneplus_sm7250.git"
                 }
         ]
 }

--- a/changelogs/changelog_avicii.txt
+++ b/changelogs/changelog_avicii.txt
@@ -3,12 +3,11 @@ Build type: Monthly
 Device: Oneplus Nord
 Device maintainer: PSavarMattas
 
+=====08th JUNE, 2023======
+
+- Selinux changes on Device Tree.
+- Conflicting code in hardware/oplus optimized.
+
 =====29th APRIL, 2023======
 
 - Sync with latest 4.7.5 source changes
-
-=====08th JUNE, 2023======
-
-- Sync with latest 4.8 source changes.
-- Device Tree Update (Maintainer Name Changed).
-- Conflicting code in hardware/oplus optimized.

--- a/changelogs/changelog_avicii.txt
+++ b/changelogs/changelog_avicii.txt
@@ -1,8 +1,14 @@
 Highlights & Device Specific Changes:
 Build type: Monthly
 Device: Oneplus Nord
-Device maintainer: Snippetguy
+Device maintainer: PSavarMattas
 
 =====29th APRIL, 2023======
 
 - Sync with latest 4.7.5 source changes
+
+=====08th JUNE, 2023======
+
+- Sync with latest 4.8 source changes.
+- Device Tree Update (Maintainer Name Changed).
+- Conflicting code in hardware/oplus optimized.

--- a/devices.json
+++ b/devices.json
@@ -189,8 +189,8 @@
       "name": "OnePlus Nord",
       "supported_versions": [
          {
-            "maintainer_name": "Snippetguy",
-            "maintainer_url": "https://t.me/snippetguy",
+            "maintainer_name": "PSavarMattas",
+            "maintainer_url": "https://t.me/psmbuilds",
             "version_code": "tiramisu",
             "version_name": "Tiramisu",
             "xda_thread": ""


### PR DESCRIPTION
- Changelog for June 8, 2023 Build is added.
- New unofficial maintainer of the device Avicii = OnePlus Nord.